### PR TITLE
Add additional tax class filters for C0 and B1

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def display_logo(context='main'):
         """, unsafe_allow_html=True)
 
 # Configure valid property classes
-VALID_PROPERTY_CLASSES = ["CD", "B9", "B2", "B3", "CO", "C0" "B1", "C1", "A9", "C2"]
+VALID_PROPERTY_CLASSES = ["CD", "B9", "B2", "B3", "CO", "C0", "B1", "C1", "C3", "A9", "C2"]
 data_processor = DataProcessor(VALID_PROPERTY_CLASSES)
 
 # Authentication check

--- a/utils/data_processor.py
+++ b/utils/data_processor.py
@@ -32,6 +32,7 @@ class DataProcessor:
         self.property_class_standardization = {
             "CO": "C0",
             "C0": "C0",
+            "B1": "B1"
         }
         
         # Address component columns


### PR DESCRIPTION
Add additional tax class filters to capture "C0" and "B1" and "C3".

* **app.py**
  - Update `VALID_PROPERTY_CLASSES` list to include "C0" and "B1"  and "C3".

* **utils/data_processor.py**
  - Add "C0" and "B1" to `property_class_standardization` mapping.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KrypticGadget/Sothebys-Internal-Apps?shareId=b699da0d-179d-47b1-b1f8-411063699629).